### PR TITLE
Clearing out dev dependencies in Candy's package.json

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -47,6 +47,7 @@ Candy Plugin Changelog
 <ul>
     <li>Added German translations (by Stephan Trzonnek)</li>
     <li>Bump json from 20180813 to 20230227</li>
+    <li>Remove dev-dependencies from third-party Candy code-base</li>
 </ul>
 
 <p><b>2.2.0 Release 3</b> -- February 22, 2022</p>

--- a/classes/candy/package.json
+++ b/classes/candy/package.json
@@ -39,27 +39,5 @@
   },
   "homepage": "http://candy-chat.github.io/candy/",
   "devDependencies": {
-    "grunt": "^0.4.5",
-    "grunt-clear": "^0.2.1",
-    "grunt-contrib-clean": "^0.5.0",
-    "grunt-contrib-compress": "^0.13.0",
-    "grunt-contrib-concat": "^0.5.1",
-    "grunt-contrib-cssmin": "^0.14.0",
-    "grunt-contrib-jshint": "^0.10.0",
-    "grunt-contrib-uglify": "^0.4.0",
-    "grunt-contrib-watch": "^0.6.1",
-    "grunt-coveralls": "^0.3.0",
-    "grunt-github-releaser": "^0.1.17",
-    "grunt-mkdir": "^0.1.1",
-    "grunt-natural-docs": "^0.1.1",
-    "grunt-notify": "^0.3.0",
-    "grunt-prompt": "^1.3.0",
-    "grunt-sync-pkg": "^0.1.2",
-    "grunt-todo": "~0.4.0",
-    "intern": "^2.0.1",
-    "jshint-stylish": "^0.2.0",
-    "lolex": "^1.2.0",
-    "sinon": "^1.10.3",
-    "sinon-chai": "^2.5.0"
   }
 }


### PR DESCRIPTION
This plugin contains the code of the Candy project, including its project files. These files define development dependencies that are outdated.

As in context of the Openfire plugin, the Candy source won't be build (instead, we consume pre-build artifacts), we can do without those dependencies.

This prevents static analysis from raising alarms over outdated dependencies.