### PR TITLE
Release 2.2.0.5

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -43,7 +43,7 @@
 Candy Plugin Changelog
 </h1>
 
-<p><b>2.2.0 Release 5</b> -- (tbd)</p>
+<p><b>2.2.0 Release 5</b> -- November 13, 2024</p>
 <ul>
     <li>Marked as last version to be compatible with Openfire versions prior to 5.0.0.</li>
     <li>Bump org.json:json from 20230227 to 20231013</li>

--- a/changelog.html
+++ b/changelog.html
@@ -45,6 +45,7 @@ Candy Plugin Changelog
 
 <p><b>2.2.0 Release 5</b> -- (tbd)</p>
 <ul>
+    <li>Marked as last version to be compatible with Openfire versions prior to 5.0.0.</li>
     <li>Bump org.json:json from 20230227 to 20231013</li>
 </ul>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -5,8 +5,9 @@
     <description>Adds the (third-party) Candy web client to Openfire.</description>
     <author>Guus der Kinderen</author>
     <version>${project.version}</version>
-    <date>2023-07-20</date>
+    <date>2024-11-13</date>
     <minServerVersion>4.7.0</minServerVersion>
+    <priorToServerVersion>5.0.0</priorToServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
     <adminconsole>
         <tab id="tab-webclients" name="${admin.sidebar.webclients.name}" description="${admin.sidebar.webclients.description}" url="candy-config.jsp">    

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>candy</artifactId>
     <name>Candy Webchat Plugin</name>
-    <version>2.2.0-release-5</version>
+    <version>2.2.0-release-6-SNAPSHOT</version>
 
     <build>
         <sourceDirectory>src/java</sourceDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>candy</artifactId>
     <name>Candy Webchat Plugin</name>
-    <version>2.2.0-release-5-SNAPSHOT</version>
+    <version>2.2.0-release-5</version>
 
     <build>
         <sourceDirectory>src/java</sourceDirectory>


### PR DESCRIPTION
Adds 'prior to' restriction to reflect incompatibility with Openfire 5.0.0 and later (because of the Jetty upgrade).