### PR TITLE
fixes #17: Openfire 5.0.0 compatibility

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,7 @@ Candy Plugin Changelog
 <p><b>2.2.0 Release 6</b> -- (to be determined)</p>
 <ul>
     <li>Minimum Openfire requirement: 5.0.0</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-candy-plugin/issues/19'>#19</a>] - Properly report version number.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-candy-plugin/issues/17'>#17</a>] - Compatibility with Openfire 5.0.0.</li>
 </ul>
 

--- a/changelog.html
+++ b/changelog.html
@@ -43,6 +43,12 @@
 Candy Plugin Changelog
 </h1>
 
+<p><b>2.2.0 Release 6</b> -- (to be determined)</p>
+<ul>
+    <li>Minimum Openfire requirement: 5.0.0</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-candy-plugin/issues/17'>#17</a>] - Compatibility with Openfire 5.0.0.</li>
+</ul>
+
 <p><b>2.2.0 Release 5</b> -- November 13, 2024</p>
 <ul>
     <li>Marked as last version to be compatible with Openfire versions prior to 5.0.0.</li>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,9 +6,7 @@
     <author>Guus der Kinderen</author>
     <version>${project.version}</version>
     <date>2024-11-19</date>
-    <minServerVersion>4.7.0</minServerVersion>
-    <priorToServerVersion>5.0.0</priorToServerVersion>
-    <minJavaVersion>1.8</minJavaVersion>
+    <minServerVersion>5.0.0</minServerVersion>
     <adminconsole>
         <tab id="tab-webclients" name="${admin.sidebar.webclients.name}" description="${admin.sidebar.webclients.description}" url="candy-config.jsp">    
             <sidebar id="tab-candy" name="${admin.sidebar.webclients.item.candy.name}" description="${admin.sidebar.webclients.item.candy.description}">

--- a/plugin.xml
+++ b/plugin.xml
@@ -5,7 +5,7 @@
     <description>Adds the (third-party) Candy web client to Openfire.</description>
     <author>Guus der Kinderen</author>
     <version>${project.version}</version>
-    <date>2024-11-13</date>
+    <date>2024-11-19</date>
     <minServerVersion>4.7.0</minServerVersion>
     <priorToServerVersion>5.0.0</priorToServerVersion>
     <minJavaVersion>1.8</minJavaVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>candy</artifactId>
     <name>Candy Webchat Plugin</name>
-    <version>2.2.0-release-6-SNAPSHOT</version>
+    <version>2.2.0.6-SNAPSHOT</version>
 
     <build>
         <sourceDirectory>src/java</sourceDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.7.0</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>candy</artifactId>
@@ -19,8 +19,8 @@
             </plugin>
             <!-- Compiles the Openfire Admin Console JSP pages. -->
             <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-jspc-maven-plugin</artifactId>
+                <groupId>org.eclipse.jetty.ee8</groupId>
+                <artifactId>jetty-ee8-jspc-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/src/java/org/igniterealtime/openfire/plugin/candy/CandyPlugin.java
+++ b/src/java/org/igniterealtime/openfire/plugin/candy/CandyPlugin.java
@@ -15,7 +15,7 @@
  */
 package org.igniterealtime.openfire.plugin.candy;
 
-import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.jetty.ee8.webapp.WebAppContext;
 import org.jivesoftware.admin.AuthCheckFilter;
 import org.jivesoftware.openfire.container.Plugin;
 import org.jivesoftware.openfire.container.PluginManager;

--- a/src/java/org/igniterealtime/openfire/plugin/candy/CandyPlugin.java
+++ b/src/java/org/igniterealtime/openfire/plugin/candy/CandyPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,6 @@ package org.igniterealtime.openfire.plugin.candy;
 
 import org.apache.tomcat.InstanceManager;
 import org.apache.tomcat.SimpleInstanceManager;
-import org.eclipse.jetty.apache.jsp.JettyJasperInitializer;
-import org.eclipse.jetty.plus.annotation.ContainerInitializer;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.jivesoftware.admin.AuthCheckFilter;
 import org.jivesoftware.openfire.container.Plugin;
@@ -29,7 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.*;
 
 /**
  * An Openfire plugin that integrates the Candy web client.
@@ -59,11 +56,6 @@ public class CandyPlugin implements Plugin
         // Add the Webchat sources to the same context as the one that's providing the BOSH interface.
         context = new WebAppContext( null, pluginDirectory.getPath() + File.separator + "classes", "/candy" );
         context.setClassLoader( this.getClass().getClassLoader() );
-
-        // Ensure the JSP engine is initialized correctly (in order to be able to cope with Tomcat/Jasper precompiled JSPs).
-        final List<ContainerInitializer> initializers = new ArrayList<>();
-        initializers.add( new ContainerInitializer( new JettyJasperInitializer(), null ) );
-        context.setAttribute("org.eclipse.jetty.containerInitializers", initializers);
         context.setAttribute( InstanceManager.class.getName(), new SimpleInstanceManager());
 
         HttpBindManager.getInstance().addJettyHandler( context );

--- a/src/java/org/igniterealtime/openfire/plugin/candy/CandyPlugin.java
+++ b/src/java/org/igniterealtime/openfire/plugin/candy/CandyPlugin.java
@@ -15,8 +15,6 @@
  */
 package org.igniterealtime.openfire.plugin.candy;
 
-import org.apache.tomcat.InstanceManager;
-import org.apache.tomcat.SimpleInstanceManager;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.jivesoftware.admin.AuthCheckFilter;
 import org.jivesoftware.openfire.container.Plugin;
@@ -56,7 +54,6 @@ public class CandyPlugin implements Plugin
         // Add the Webchat sources to the same context as the one that's providing the BOSH interface.
         context = new WebAppContext( null, pluginDirectory.getPath() + File.separator + "classes", "/candy" );
         context.setClassLoader( this.getClass().getClassLoader() );
-        context.setAttribute( InstanceManager.class.getName(), new SimpleInstanceManager());
 
         HttpBindManager.getInstance().addJettyHandler( context );
     }


### PR DESCRIPTION
Various commits that make this plugin compatible with Openfire 5.0.0, in particular in context of the update of the embedded webserver (Jetty) that this release contains.

Also contains a fix for #19 that slightly modifies the Maven version identifier used by this project.